### PR TITLE
Bugfix Undo button

### DIFF
--- a/gameyapi/gamey-service.js
+++ b/gameyapi/gamey-service.js
@@ -384,6 +384,32 @@ gameyService.post('/play/:gameId/bot-move', async (req, res) => {
   }
 });
 
+gameyService.post('/play/:gameId/undo', (req, res) => {
+  const s = sessions.get(req.params.gameId);
+  if (!s) return res.status(404).json({ error: 'Game not found' });
+  if (s.moves.length === 0) return res.status(400).json({ error: 'No moves to undo' });
+
+  // In hvb mode, undo both the bot's and human's move if the bot already responded
+  // (currentPlayer === 0 means it's human's turn, so bot already moved).
+  // If currentPlayer === 1, only the human has moved — undo just 1.
+  // In hvh mode, always undo just the last move.
+  let undoCount = 1;
+  if (s.mode === 'hvb' && s.currentPlayer === 0 && s.moves.length >= 2) {
+    undoCount = 2;
+  }
+  const undoCount_safe = Math.min(undoCount, s.moves.length);
+  s.moves.splice(-undoCount_safe, undoCount_safe);
+
+  // Recalculate game state
+  s.currentPlayer = s.moves.length % 2 === 0 ? 0 : 1;
+  s.status = 'ongoing';
+  s.winner = null;
+  s.winningPath = undefined;
+
+  console.log(`[UNDO] game=${s.id} removed=${undoCount_safe} remaining=${s.moves.length}`);
+  return res.json(sessionView(s));
+});
+
 gameyService.post('/play/:gameId/rematch', (req, res) => {
   const old = sessions.get(req.params.gameId);
   if (!old) return res.status(404).json({ error: 'Game not found' });

--- a/gameyapi/openapi.yaml
+++ b/gameyapi/openapi.yaml
@@ -241,6 +241,36 @@ paths:
                     type: string
                     example: "connect ECONNREFUSED 127.0.0.1:4000"
 
+  /play/{gameId}/undo:
+    post:
+      tags: [Game]
+      summary: Undo the last move(s)
+      description: >
+        Reverts the last move(s) from the game session. In hvb mode, undoes both
+        the human's and bot's last moves (2 moves) if the bot has already responded.
+        If only the human has moved (currentPlayer = 1), undoes just 1 move.
+        In hvh mode, always undoes exactly 1 move.
+      parameters:
+        - $ref: '#/components/parameters/gameId'
+      responses:
+        '200':
+          description: Undo successful — returns updated game state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameSession'
+        '400':
+          description: No moves to undo
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                noMoves:
+                  value: { error: "No moves to undo" }
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /play/{gameId}/rematch:
     post:
       tags: [Game]

--- a/webapp/src/GameBoard.tsx
+++ b/webapp/src/GameBoard.tsx
@@ -202,21 +202,10 @@ export default function GameBoard() {
   // ── Undo
   const handleUndo = async () => {
     if (!session || session.moves.length === 0) return;
-    const movesToKeep =
-      session.mode === 'hvb' ? session.moves.slice(0, -2) : session.moves.slice(0, -1);
 
     try {
-      await fetch(`${API_URL}/play/${session.gameId}`, { method: 'DELETE' });
-      const fresh = await apiPost<GameSession>('/play/create', {
-        mode: session.mode,
-        difficulty: session.difficulty || selectedDifficulty,
-        boardSize: session.boardSize,
-      });
-      let current: GameSession = fresh;
-      for (const m of movesToKeep) {
-        current = await apiPost<GameSession>(`/play/${fresh.gameId}/move`, m);
-      }
-      syncFromSession(current);
+      const data = await apiPost<GameSession>(`/play/${session.gameId}/undo`, {});
+      syncFromSession(data);
       setErrorMsg(null);
       setWinner(null);
       setWinningPathIndices(new Set());
@@ -396,7 +385,7 @@ export default function GameBoard() {
           <button
             className="game-action-btn btn-undo"
             onClick={handleUndo}
-            disabled={!session || session.moves.length === 0 || gameStatus !== 'ongoing'}
+            disabled={!session || session.moves.length === 0 || gameStatus !== 'ongoing' || isBotThinking}
           >
             UNDO
           </button>


### PR DESCRIPTION
- Fixed a bug where the Undo button only worked after the first turn when playing against the computer. Clicking Undo on the second turn or later caused an error and broke the game. (The old undo logic deleted the game session, recreated it, and replayed all previous moves); 

- Added a new POST /play/:gameId/undo endpoint that directly removes the last move(s) from the session in-memory (2 in HvB mode, 1 in HvH mode) and resets the game state