### PR TITLE
feat: add easy level bot and integrate frontend difficulty selection

### DIFF
--- a/gamey/src/bot/easy_level_bot.rs
+++ b/gamey/src/bot/easy_level_bot.rs
@@ -47,49 +47,59 @@ impl YBot for easy_level_bot {
 impl easy_level_bot {
     fn evaluate_board(&self, board: &GameY, bot_id: u32) -> i32 {
         let size = board.board_size();
-        let yen: YEN = board.into();
+        let yen: crate::YEN = board.into();
         let layout: Vec<char> = yen.layout().replace("/", "").chars().collect();
         
         let my_char = if bot_id == 0 { 'R' } else { 'B' };
-
         let mut score = 0;
 
         for (i, &c) in layout.iter().enumerate() {
             if c == '.' { continue; }
             
-            let coords = Coordinates::from_index(i as u32, size);
-            let mut val = 0;
-
-            let x = coords.x() as i32;
-            let y = coords.y() as i32;
-
-            // Check 6 hexagonal neighbors for clustering
-            let neighbors = [(1,0), (-1,0), (0,1), (0,-1), (1,-1), (-1,1)];
-
-            for (dx, dy) in neighbors {
-                let nx = x + dx;
-                let ny = y + dy;
-                if nx >= 0 && ny >= 0 && (nx + ny) < size as i32 {
-                    let neighbor_coords = Coordinates::new(nx as u32, ny as u32, (size as i32 - 1 - nx - ny) as u32);
-                    let n_idx = neighbor_coords.to_index(size) as usize;
-                    if n_idx < layout.len() && layout[n_idx] == c {
-                        val += 150; 
-                    }
-                }
-            }
-
-            // High reward for touching the edges of the board
-            if coords.touches_side_a() { val += 1000; }
-            if coords.touches_side_b() { val += 1000; }
-            if coords.touches_side_c() { val += 1000; }
+            let coords = crate::Coordinates::from_index(i as u32, size);
+          
+            let mut val = self.evaluate_neighbors(&coords, c, &layout, size);
+            val += self.evaluate_edges(&coords);
 
             if c == my_char {
                 score += val;
             } else {
-                // Defensive penalty: prioritize blocking the opponent
+                // Defensive penalty
                 score -= (val as f32 * 1.2) as i32; 
             }
         }
         score
+    }
+
+  
+    fn evaluate_neighbors(&self, coords: &crate::Coordinates, c: char, layout: &[char], size: u32) -> i32 {
+        let mut val = 0;
+        let x = coords.x() as i32;
+        let y = coords.y() as i32;
+        let neighbors = [(1,0), (-1,0), (0,1), (0,-1), (1,-1), (-1,1)];
+
+        for (dx, dy) in neighbors {
+            let nx = x + dx;
+            let ny = y + dy;
+            
+            if nx >= 0 && ny >= 0 && (nx + ny) < size as i32 {
+                let z = (size as i32 - 1 - nx - ny) as u32;
+                let neighbor_coords = crate::Coordinates::new(nx as u32, ny as u32, z);
+                let n_idx = neighbor_coords.to_index(size) as usize;
+                
+                if n_idx < layout.len() && layout[n_idx] == c {
+                    val += 150; 
+                }
+            }
+        }
+        val
+    }
+
+    fn evaluate_edges(&self, coords: &crate::Coordinates) -> i32 {
+        let mut val = 0;
+        if coords.touches_side_a() { val += 1000; }
+        if coords.touches_side_b() { val += 1000; }
+        if coords.touches_side_c() { val += 1000; }
+        val
     }
 }

--- a/gamey/src/bot/easy_level_bot.rs
+++ b/gamey/src/bot/easy_level_bot.rs
@@ -1,0 +1,95 @@
+use crate::{Coordinates, GameY, YBot, Movement, PlayerId, YEN};
+use rand::prelude::IndexedRandom; // For randomly selecting among equally good moves
+
+pub struct easy_level_bot;
+
+impl YBot for easy_level_bot {
+    fn name(&self) -> &str { "easy_level_bot" }
+
+    fn choose_move(&self, board: &GameY) -> Option<Coordinates> {
+        let size = board.board_size();
+        let available = board.available_cells();
+        let bot_player_id = board.next_player().map(|p| p.id()).unwrap_or(0);
+
+        let mut best_score = i32::MIN;
+        let mut best_moves = Vec::new(); 
+
+        for &idx in available.iter() {
+            let coords = Coordinates::from_index(idx, size);
+            let mut virtual_board = board.clone();
+            
+            let movement = Movement::Placement {
+                player: PlayerId::new(bot_player_id),
+                coords,
+            };
+
+            // Evaluate only one move ahead (greedy approach, no Minimax)
+            if virtual_board.add_move(movement).is_ok() {
+                let score = self.evaluate_board(&virtual_board, bot_player_id);
+                
+                if score > best_score {
+                    // Found a new best score, reset the list with the new move
+                    best_score = score;
+                    best_moves.clear();
+                    best_moves.push(coords);
+                } else if score == best_score {
+                    // Tie-breaker: keep track of all moves with the best score
+                    best_moves.push(coords);
+                }
+            }
+        }
+        
+        let mut rng = rand::rng();
+        best_moves.choose(&mut rng).copied()
+    }
+}
+
+impl easy_level_bot {
+    fn evaluate_board(&self, board: &GameY, bot_id: u32) -> i32 {
+        let size = board.board_size();
+        let yen: YEN = board.into();
+        let layout: Vec<char> = yen.layout().replace("/", "").chars().collect();
+        
+        let my_char = if bot_id == 0 { 'R' } else { 'B' };
+
+        let mut score = 0;
+
+        for (i, &c) in layout.iter().enumerate() {
+            if c == '.' { continue; }
+            
+            let coords = Coordinates::from_index(i as u32, size);
+            let mut val = 0;
+
+            let x = coords.x() as i32;
+            let y = coords.y() as i32;
+
+            // Check 6 hexagonal neighbors for clustering
+            let neighbors = [(1,0), (-1,0), (0,1), (0,-1), (1,-1), (-1,1)];
+
+            for (dx, dy) in neighbors {
+                let nx = x + dx;
+                let ny = y + dy;
+                if nx >= 0 && ny >= 0 && (nx + ny) < size as i32 {
+                    let neighbor_coords = Coordinates::new(nx as u32, ny as u32, (size as i32 - 1 - nx - ny) as u32);
+                    let n_idx = neighbor_coords.to_index(size) as usize;
+                    if n_idx < layout.len() && layout[n_idx] == c {
+                        val += 150; 
+                    }
+                }
+            }
+
+            // High reward for touching the edges of the board
+            if coords.touches_side_a() { val += 1000; }
+            if coords.touches_side_b() { val += 1000; }
+            if coords.touches_side_c() { val += 1000; }
+
+            if c == my_char {
+                score += val;
+            } else {
+                // Defensive penalty: prioritize blocking the opponent
+                score -= (val as f32 * 1.2) as i32; 
+            }
+        }
+        score
+    }
+}

--- a/gamey/src/bot/mod.rs
+++ b/gamey/src/bot/mod.rs
@@ -10,6 +10,8 @@
 pub mod ybot;
 pub mod ybot_registry;
 pub mod gamer_bot;
+pub mod easy_level_bot;
 pub use ybot::*;
 pub use ybot_registry::*;
 pub use gamer_bot::*;
+pub use easy_level_bot::*;

--- a/gamey/src/bot_server/mod.rs
+++ b/gamey/src/bot_server/mod.rs
@@ -30,6 +30,7 @@ pub use error::ErrorResponse;
 pub use version::*;
 
 use crate::{GameYError, GamerBot, YBotRegistry, state::AppState};
+use crate::bot::easy_level_bot::easy_level_bot;
 use tower_http::cors::CorsLayer;
 
 /// Creates the Axum router with the given state.
@@ -52,7 +53,7 @@ pub fn create_router(state: AppState) -> axum::Router {
 ///
 /// The default state includes the `GamerBot` which selects moves using a minimax algorithm.
 pub fn create_default_state() -> AppState {
-    let bots = YBotRegistry::new().with_bot(Arc::new(GamerBot));
+    let bots = YBotRegistry::new().with_bot(Arc::new(GamerBot)).with_bot(Arc::new(easy_level_bot));
     AppState::new(bots)
 }
 

--- a/gamey/tests/easy_level_bot_test.rs
+++ b/gamey/tests/easy_level_bot_test.rs
@@ -1,0 +1,93 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Movement, PlayerId};
+
+    #[test]
+    fn test_easy_bot_name() {
+        let bot = easy_level_bot;
+        assert_eq!(bot.name(), "easy_level_bot");
+    }
+
+    #[test]
+    fn test_easy_bot_returns_move_on_empty_board() {
+        let bot = easy_level_bot;
+        let game = GameY::new(5);
+
+        let chosen_move = bot.choose_move(&game);
+        assert!(chosen_move.is_some(), "Bot should return a move on an empty board");
+    }
+
+    #[test]
+    fn test_easy_bot_returns_valid_coordinates() {
+        let bot = easy_level_bot;
+        let game = GameY::new(5);
+
+        let coords = bot.choose_move(&game).unwrap();
+        let index = coords.to_index(game.board_size());
+
+        // The total number of cells on a hex board of size N is (N * (N + 1)) / 2
+        assert!(index < 15, "Chosen coordinates must be within board limits");
+    }
+
+    #[test]
+    fn test_easy_bot_returns_none_on_full_board() {
+        let bot = easy_level_bot;
+        let mut game = GameY::new(2);
+
+        let moves = vec![
+            Movement::Placement {
+                player: PlayerId::new(0),
+                coords: Coordinates::new(1, 0, 0),
+            },
+            Movement::Placement {
+                player: PlayerId::new(1),
+                coords: Coordinates::new(0, 1, 0),
+            },
+            Movement::Placement {
+                player: PlayerId::new(0),
+                coords: Coordinates::new(0, 0, 1),
+            },
+        ];
+
+        for mv in moves {
+            game.add_move(mv).unwrap();
+        }
+
+        assert!(game.available_cells().is_empty(), "Board must be full for this test");
+        let chosen_move = bot.choose_move(&game);
+        assert!(chosen_move.is_none(), "Bot should return None on a full board");
+    }
+
+    #[test]
+    fn test_easy_bot_chooses_from_available_cells() {
+        let bot = easy_level_bot;
+        let mut game = GameY::new(3);
+
+        game.add_move(Movement::Placement {
+            player: PlayerId::new(0),
+            coords: Coordinates::new(2, 0, 0),
+        })
+        .unwrap();
+
+        let coords = bot.choose_move(&game).unwrap();
+        let index = coords.to_index(game.board_size());
+
+        assert!(game.available_cells().contains(&index), "Bot selected an occupied cell");
+    }
+    
+    #[test]
+    fn test_easy_bot_multiple_calls_return_valid_moves() {
+        let bot = easy_level_bot;
+        let game = GameY::new(7);
+
+        // Verify that the random selection consistently returns valid cells over multiple runs
+        for _ in 0..10 {
+            let coords = bot.choose_move(&game).unwrap()
+            let index = coords.to_index(game.board_size());
+
+            assert!(index < 28);
+            assert!(game.available_cells().contains(&index));
+        }
+    }
+}

--- a/gamey/tests/easy_level_bot_test.rs
+++ b/gamey/tests/easy_level_bot_test.rs
@@ -1,93 +1,90 @@
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{Movement, PlayerId};
+use gamey::{Coordinates, GameY, Movement, PlayerId, YBot};
+use gamey::easy_level_bot;
 
-    #[test]
-    fn test_easy_bot_name() {
-        let bot = easy_level_bot;
-        assert_eq!(bot.name(), "easy_level_bot");
-    }
+#[test]
+fn test_easy_bot_name() {
+    let bot = easy_level_bot;
+    assert_eq!(bot.name(), "easy_level_bot");
+}
 
-    #[test]
-    fn test_easy_bot_returns_move_on_empty_board() {
-        let bot = easy_level_bot;
-        let game = GameY::new(5);
+#[test]
+fn test_easy_bot_returns_move_on_empty_board() {
+    let bot = easy_level_bot;
+    let game = GameY::new(5);
 
-        let chosen_move = bot.choose_move(&game);
-        assert!(chosen_move.is_some(), "Bot should return a move on an empty board");
-    }
+    let chosen_move = bot.choose_move(&game);
+    assert!(chosen_move.is_some(), "Bot should return a move on an empty board");
+}
 
-    #[test]
-    fn test_easy_bot_returns_valid_coordinates() {
-        let bot = easy_level_bot;
-        let game = GameY::new(5);
+#[test]
+fn test_easy_bot_returns_valid_coordinates() {
+    let bot = easy_level_bot;
+    let game = GameY::new(5);
 
-        let coords = bot.choose_move(&game).unwrap();
-        let index = coords.to_index(game.board_size());
+    let coords = bot.choose_move(&game).unwrap();
+    let index = coords.to_index(game.board_size());
 
-        // The total number of cells on a hex board of size N is (N * (N + 1)) / 2
-        assert!(index < 15, "Chosen coordinates must be within board limits");
-    }
+    // The total number of cells on a hex board of size N is (N * (N + 1)) / 2
+    assert!(index < 15, "Chosen coordinates must be within board limits");
+}
 
-    #[test]
-    fn test_easy_bot_returns_none_on_full_board() {
-        let bot = easy_level_bot;
-        let mut game = GameY::new(2);
+#[test]
+fn test_easy_bot_returns_none_on_full_board() {
+    let bot = easy_level_bot;
+    let mut game = GameY::new(2);
 
-        let moves = vec![
-            Movement::Placement {
-                player: PlayerId::new(0),
-                coords: Coordinates::new(1, 0, 0),
-            },
-            Movement::Placement {
-                player: PlayerId::new(1),
-                coords: Coordinates::new(0, 1, 0),
-            },
-            Movement::Placement {
-                player: PlayerId::new(0),
-                coords: Coordinates::new(0, 0, 1),
-            },
-        ];
-
-        for mv in moves {
-            game.add_move(mv).unwrap();
-        }
-
-        assert!(game.available_cells().is_empty(), "Board must be full for this test");
-        let chosen_move = bot.choose_move(&game);
-        assert!(chosen_move.is_none(), "Bot should return None on a full board");
-    }
-
-    #[test]
-    fn test_easy_bot_chooses_from_available_cells() {
-        let bot = easy_level_bot;
-        let mut game = GameY::new(3);
-
-        game.add_move(Movement::Placement {
+    let moves = vec![
+        Movement::Placement {
             player: PlayerId::new(0),
-            coords: Coordinates::new(2, 0, 0),
-        })
-        .unwrap();
+            coords: Coordinates::new(1, 0, 0),
+        },
+        Movement::Placement {
+            player: PlayerId::new(1),
+            coords: Coordinates::new(0, 1, 0),
+        },
+        Movement::Placement {
+            player: PlayerId::new(0),
+            coords: Coordinates::new(0, 0, 1),
+        },
+    ];
 
-        let coords = bot.choose_move(&game).unwrap();
+    for mv in moves {
+        game.add_move(mv).unwrap();
+    }
+
+    assert!(game.available_cells().is_empty(), "Board must be full for this test");
+    let chosen_move = bot.choose_move(&game);
+    assert!(chosen_move.is_none(), "Bot should return None on a full board");
+}
+
+#[test]
+fn test_easy_bot_chooses_from_available_cells() {
+    let bot = easy_level_bot;
+    let mut game = GameY::new(3);
+
+    game.add_move(Movement::Placement {
+        player: PlayerId::new(0),
+        coords: Coordinates::new(2, 0, 0),
+    })
+    .unwrap();
+
+    let coords = bot.choose_move(&game).unwrap();
+    let index = coords.to_index(game.board_size());
+
+    assert!(game.available_cells().contains(&index), "Bot selected an occupied cell");
+}
+
+#[test]
+fn test_easy_bot_multiple_calls_return_valid_moves() {
+    let bot = easy_level_bot;
+    let game = GameY::new(7);
+
+    // Verify that the random selection consistently returns valid cells over multiple runs
+    for _ in 0..10 {
+        let coords = bot.choose_move(&game).unwrap(); // Noktalı virgül eklendi!
         let index = coords.to_index(game.board_size());
 
-        assert!(game.available_cells().contains(&index), "Bot selected an occupied cell");
-    }
-    
-    #[test]
-    fn test_easy_bot_multiple_calls_return_valid_moves() {
-        let bot = easy_level_bot;
-        let game = GameY::new(7);
-
-        // Verify that the random selection consistently returns valid cells over multiple runs
-        for _ in 0..10 {
-            let coords = bot.choose_move(&game).unwrap()
-            let index = coords.to_index(game.board_size());
-
-            assert!(index < 28);
-            assert!(game.available_cells().contains(&index));
-        }
+        assert!(index < 28);
+        assert!(game.available_cells().contains(&index));
     }
 }

--- a/gameyapi/gamey-service.js
+++ b/gameyapi/gamey-service.js
@@ -213,12 +213,22 @@ function randomFreeCell(moves, boardSize) {
   return free[Math.floor(Math.random() * free.length)];
 }
 
-async function getBotMove(moves, boardSize, nextPlayer) {
+async function getBotMove(moves, boardSize, nextPlayer,difficulty) {
   const yen = buildYEN(moves, boardSize, nextPlayer);
   console.log('[YEN sent to Rust]', JSON.stringify(yen));
 
+  let botToCall = 'gamer_bot';
+  
+  if (difficulty === 'beginner') {
+    botToCall = 'easy_level_bot'; 
+  } else if (difficulty === 'advanced') {
+    botToCall = 'gamer_bot'; 
+  }
+
+  console.log(`[BOT] Difficulty: ${difficulty} -> Target Bot: ${botToCall}`);
+
   const res = await fetch(
-      `${GAMEY_RUST_URL}/${API_VERSION}/ybot/choose/${BOT_ID}`,
+      `${GAMEY_RUST_URL}/${API_VERSION}/ybot/choose/${botToCall}`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -250,8 +260,8 @@ async function getBotMove(moves, boardSize, nextPlayer) {
 
 // ─── Session helpers ──────────────────────────────────────────────────────────
 
-function newSession(id, mode, boardSize) {
-  return { id, mode, boardSize, moves: [], status: 'ongoing', currentPlayer: 0, winner: null };
+function newSession(id, mode, boardSize, difficulty) {
+  return { id, mode, boardSize, difficulty: difficulty || 'medium', moves: [], status: 'ongoing', currentPlayer: 0, winner: null };
 }
 
 function sessionView(s) {
@@ -275,14 +285,14 @@ function isBoardFull(moves, boardSize) {
 // ─── Routes ───────────────────────────────────────────────────────────────────
 
 gameyService.post('/play/create', (req, res) => {
-  const { mode, boardSize = 11 } = req.body;
+  const { mode, boardSize = 11, difficulty } = req.body;
   if (!['hvh', 'hvb'].includes(mode))
     return res.status(400).json({ error: "mode must be 'hvh' or 'hvb'" });
   if (!Number.isInteger(boardSize) || boardSize < 2 || boardSize > 11)
     return res.status(400).json({ error: 'boardSize must be an integer between 2 and 11' });
 
   const id = uuidv4();
-  sessions.set(id, newSession(id, mode, boardSize));
+ sessions.set(id, newSession(id, mode, boardSize, difficulty));
   console.log(`[CREATE] game=${id} mode=${mode} size=${boardSize}`);
   return res.status(201).json(sessionView(sessions.get(id)));
 });
@@ -328,7 +338,7 @@ gameyService.post('/play/:gameId/move', async (req, res) => {
 
   if (s.mode === 'hvb' && s.status === 'ongoing') {
     try {
-      const botCoords = await getBotMove(s.moves, s.boardSize, s.currentPlayer);
+      const botCoords = await getBotMove(s.moves, s.boardSize, s.currentPlayer, s.difficulty);
 
       if (!botCoords) {
         s.status = 'finished';
@@ -369,7 +379,7 @@ gameyService.post('/play/:gameId/bot-move', async (req, res) => {
   if (s.currentPlayer !== 1) return res.status(400).json({ error: "It is the human's turn" });
 
   try {
-    const botCoords = await getBotMove(s.moves, s.boardSize, s.currentPlayer);
+    const botCoords = await getBotMove(s.moves, s.boardSize, s.currentPlayer, s.difficulty);
     s.moves.push({ player: 1, ...botCoords });
     s.currentPlayer = 0;
 
@@ -414,7 +424,7 @@ gameyService.post('/play/:gameId/rematch', (req, res) => {
   const old = sessions.get(req.params.gameId);
   if (!old) return res.status(404).json({ error: 'Game not found' });
   const id = uuidv4();
-  sessions.set(id, newSession(id, old.mode, old.boardSize));
+  sessions.set(id, newSession(id, old.mode, old.boardSize, old.difficulty));
   sessions.delete(old.id);
   console.log(`[REMATCH] new=${id} old=${old.id}`);
   return res.status(201).json(sessionView(sessions.get(id)));

--- a/gameyapi/gamey-service.js
+++ b/gameyapi/gamey-service.js
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 const gameyService = express();
 const PORT = process.env.PORT || 3001;
 const GAMEY_RUST_URL = process.env.GAMEY_RUST_URL || 'http://localhost:4000';
-const BOT_ID = 'gamer_bot';
+
 const API_VERSION = 'v1';
 
 gameyService.use(cors());
@@ -221,7 +221,9 @@ async function getBotMove(moves, boardSize, nextPlayer,difficulty) {
   
   if (difficulty === 'beginner') {
     botToCall = 'easy_level_bot'; 
-  } else if (difficulty === 'advanced') {
+  }else if (difficulty === 'medium') {
+     botToCall = 'gamer_bot'; }
+  else if (difficulty === 'advanced') {
     botToCall = 'gamer_bot'; 
   }
 
@@ -261,7 +263,7 @@ async function getBotMove(moves, boardSize, nextPlayer,difficulty) {
 // ─── Session helpers ──────────────────────────────────────────────────────────
 
 function newSession(id, mode, boardSize, difficulty) {
-  return { id, mode, boardSize, difficulty: difficulty || 'medium', moves: [], status: 'ongoing', currentPlayer: 0, winner: null };
+  return { id, mode, boardSize, difficulty: difficulty, moves: [], status: 'ongoing', currentPlayer: 0, winner: null };
 }
 
 function sessionView(s) {

--- a/webapp/src/GameBoard.tsx
+++ b/webapp/src/GameBoard.tsx
@@ -161,6 +161,7 @@ export default function GameBoard({ username = "Guest User" }: GameBoardProps) {
 
   // ── Start a new game
   const handleStartGame = async () => {
+    alert(`TEST ALERT: Starting game in "${selectedDifficulty}" difficulty!`);
     setErrorMsg(null);
     setWinner(null);
     setWinningPathIndices(new Set());

--- a/webapp/src/GameBoard.tsx
+++ b/webapp/src/GameBoard.tsx
@@ -161,7 +161,6 @@ export default function GameBoard({ username = "Guest User" }: GameBoardProps) {
 
   // ── Start a new game
   const handleStartGame = async () => {
-    alert(`TEST ALERT: Starting game in "${selectedDifficulty}" difficulty!`);
     setErrorMsg(null);
     setWinner(null);
     setWinningPathIndices(new Set());


### PR DESCRIPTION
Created easy_level_bot.rs which uses a greedy evaluation approach (evaluating only 1 move ahead) and successfully integrated it with the frontend.