### PR TITLE
feat: add how to play modal and tests to lobby screen

### DIFF
--- a/webapp/src/Lobby.css
+++ b/webapp/src/Lobby.css
@@ -325,3 +325,142 @@ body {
   }
 
 }
+/* Navigation actions layout */
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem; 
+}
+
+/* Help button styles with inverse hover effect */
+.help-icon-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: #483dff; 
+  color: #fff; 
+  font-size: 20px;
+  font-weight: bold;
+  border: 2px solid #483dff; 
+  cursor: pointer;
+  box-shadow: 0 0 15px rgba(72, 61, 255, 0.4); 
+  transition: all 0.2s ease;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+}
+
+.help-icon-button:hover {
+  background-color: transparent; 
+  color: #483dff; 
+  box-shadow: 0 0 10px rgba(72, 61, 255, 0.15); 
+}
+
+/* Modal background and positioning */
+.how-to-play-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.85); 
+  backdrop-filter: blur(5px); 
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  animation: fadeIn 0.3s ease; 
+}
+
+.how-to-play-content {
+  background-color: #1a1a1a; 
+  padding: 2.5rem;
+  border: 1px solid #333; 
+  border-radius: 4px; 
+  max-width: 600px;
+  width: 90%;
+  text-align: left;
+  box-shadow: 0 0 30px rgba(0, 0, 0, 0.9); 
+  max-height: 80vh; 
+  overflow-y: auto; 
+}
+
+.how-to-play-content .modal-title {
+  color: #483dff; 
+  font-size: 1.2rem;
+  font-weight: bold;
+  margin-top: 0;
+  margin-bottom: 2rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  border-bottom: 2px solid #333;
+  padding-bottom: 0.8rem;
+}
+
+/* Rules content formatting */
+.rules-list {
+  color: #ccc;
+  line-height: 1.7;
+}
+
+.rules-list h3 {
+  display: flex;
+  align-items: center;
+  font-size: 1.1rem;
+  color: #fff;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.step-num {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 28px;
+  height: 28px;
+  background-color: transparent;
+  color: #483dff;
+  border: 1px solid #483dff;
+  border-radius: 50%;
+  margin-right: 12px;
+  font-size: 0.9rem;
+  font-weight: bold;
+  box-shadow: 0 0 5px rgba(72, 61, 255, 0.2);
+}
+
+.rules-list p {
+  margin: 0 0 1.5rem 40px; 
+  font-size: 1rem;
+}
+
+/* Modal action button */
+.close-modal-btn {
+  margin-top: 2rem;
+  padding: 1rem;
+  width: 100%;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  background-color: #483dff; 
+  color: white; 
+  border: 1px solid #483dff; 
+  box-shadow: 0 0 15px rgba(72, 61, 255, 0.5); 
+}
+
+.close-modal-btn:hover {
+  background-color: transparent; 
+  color: #483dff; 
+  box-shadow: 0 0 10px rgba(72, 61, 255, 0.15); 
+}
+
+/* Base animations */
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}

--- a/webapp/src/Lobby.tsx
+++ b/webapp/src/Lobby.tsx
@@ -106,29 +106,27 @@ const Lobby: React.FC<LobbyProps> = ({ username = "Guest User", onPlay, onLogout
           </div>
         </main>
          {/* Modal structure for Game Y rules */}
-        {showHowToPlay && (
-            <div 
-                className="how-to-play-overlay" 
-                onClick={toggleHowToPlay}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === 'Escape') toggleHowToPlay();
-                }}
-                role="button"
-                tabIndex={0}
-            >
-                <div 
+       {showHowToPlay && (
+            <div className="how-to-play-overlay">
+                <button 
+                    onClick={toggleHowToPlay}
+                    aria-label="Close modal background"
+                    style={{ 
+                        position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', 
+                        background: 'transparent', border: 'none', cursor: 'default' 
+                    }}
+                />
+                <dialog 
+                    open
                     className="how-to-play-content" 
-                    onClick={(e) => e.stopPropagation()}
-                    onKeyDown={(e) => e.stopPropagation()}
-                    role="dialog"
-                    aria-modal="true"
-                    aria-label="How to play instructions"
+                    style={{ position: 'relative', zIndex: 1 }}
                 >
                     <h2 className="modal-title">HOW TO PLAY: GAME Y</h2>
                     
                     <div className="rules-list">
                       <h3><span className="step-num">1</span> Objective</h3>
                       <p>Connect all three sides of the triangular board with a continuous chain of your stones.</p>
+                      
                       <h3><span className="step-num">2</span> Modes & Difficulty</h3>
                       <p>Choose "Player vs. Player" for a local match, or "Player vs. Computer" to challenge the AI. You can adjust the AI's level from Beginner to Advanced.</p>
                       
@@ -148,7 +146,7 @@ const Lobby: React.FC<LobbyProps> = ({ username = "Guest User", onPlay, onLogout
                     <button className="close-modal-btn" onClick={toggleHowToPlay}>
                         Got it!
                     </button>
-                </div>
+                </dialog>
             </div>
         )}
       </div>

--- a/webapp/src/Lobby.tsx
+++ b/webapp/src/Lobby.tsx
@@ -113,13 +113,16 @@ const Lobby: React.FC<LobbyProps> = ({ username = "Guest User", onPlay, onLogout
                 onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === 'Escape') toggleHowToPlay();
                 }}
-                role="presentation"
+                role="button"
+                tabIndex={0}
             >
                 <div 
                     className="how-to-play-content" 
                     onClick={(e) => e.stopPropagation()}
                     onKeyDown={(e) => e.stopPropagation()}
-                    role="presentation"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="How to play instructions"
                 >
                     <h2 className="modal-title">HOW TO PLAY: GAME Y</h2>
                     

--- a/webapp/src/Lobby.tsx
+++ b/webapp/src/Lobby.tsx
@@ -12,13 +12,21 @@ const Lobby: React.FC<LobbyProps> = ({ username = "Guest User", onPlay, onLogout
   const [selectedMode, setSelectedMode] = useState('pvp');
   const [selectedDifficulty, setSelectedDifficulty] = useState('beginner');
   const [boardSize, setBoardSize] = useState(11);
+  const [showHowToPlay, setShowHowToPlay] = useState(false);
+  const toggleHowToPlay = () => setShowHowToPlay(!showHowToPlay);
   const friends = ["Alice_99", "Bob_Builder", "Charlie_Hex"];
 
   return (
       <div className="lobby-page-wrapper">
         <nav className="lobby-navbar">
           <div className="nav-logo">GAME Y</div>
-          <button className="nav-logout-btn" onClick={onLogout}>Logout</button>
+          
+          <div className="nav-actions">
+            <button className="help-icon-button" onClick={toggleHowToPlay} title="How to Play">
+                ?
+            </button>
+            <button className="nav-logout-btn" onClick={onLogout}>Logout</button>
+          </div>
         </nav>
 
         <main className="lobby-main-content">
@@ -97,6 +105,37 @@ const Lobby: React.FC<LobbyProps> = ({ username = "Guest User", onPlay, onLogout
             </aside>
           </div>
         </main>
+         {/* Modal structure for Game Y rules */}
+        {showHowToPlay && (
+            <div className="how-to-play-overlay" onClick={toggleHowToPlay}>
+                <div className="how-to-play-content" onClick={(e) => e.stopPropagation()}>
+                    <h2 className="modal-title">HOW TO PLAY: GAME Y</h2>
+                    
+                    <div className="rules-list">
+                      <h3><span className="step-num">1</span> Objective</h3>
+                      <p>Connect all three sides of the triangular board with a continuous chain of your stones.</p>
+                      <h3><span className="step-num">2</span> Modes & Difficulty</h3>
+                      <p>Choose "Player vs. Player" for a local match, or "Player vs. Computer" to challenge the AI. You can adjust the AI's level from Beginner to Advanced.</p>
+                      
+                      <h3><span className="step-num">3</span> Board & Corners</h3>
+                      <p>The game is played on a triangular grid. The corner cells act as part of both adjacent sides.</p>
+                      
+                      <h3><span className="step-num">4</span> Turns</h3>
+                      <p>Players take turns placing one stone of their color on any empty space on the board.</p>
+                      
+                      <h3><span className="step-num">5</span> Placement & Undo</h3>
+                      <p>Stones connect by sharing adjacent edges. You can use the Undo button to take back your last move if you make a mistake.</p>
+                      
+                      <h3><span className="step-num">6</span> Winning</h3>
+                      <p>The first player to form a path connecting all three sides wins. Mathematically, this game can never end in a draw!</p>
+                    </div>
+
+                    <button className="close-modal-btn" onClick={toggleHowToPlay}>
+                        Got it!
+                    </button>
+                </div>
+            </div>
+        )}
       </div>
   );
 };

--- a/webapp/src/Lobby.tsx
+++ b/webapp/src/Lobby.tsx
@@ -107,8 +107,20 @@ const Lobby: React.FC<LobbyProps> = ({ username = "Guest User", onPlay, onLogout
         </main>
          {/* Modal structure for Game Y rules */}
         {showHowToPlay && (
-            <div className="how-to-play-overlay" onClick={toggleHowToPlay}>
-                <div className="how-to-play-content" onClick={(e) => e.stopPropagation()}>
+            <div 
+                className="how-to-play-overlay" 
+                onClick={toggleHowToPlay}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === 'Escape') toggleHowToPlay();
+                }}
+                role="presentation"
+            >
+                <div 
+                    className="how-to-play-content" 
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    role="presentation"
+                >
                     <h2 className="modal-title">HOW TO PLAY: GAME Y</h2>
                     
                     <div className="rules-list">

--- a/webapp/src/__tests__/Lobby.test.tsx
+++ b/webapp/src/__tests__/Lobby.test.tsx
@@ -69,4 +69,20 @@ describe('App & Lobby Coverage Booster', () => {
     render(<App />);
     expect(screen.getByText(/Register/i)).toBeInTheDocument();
   });
+  
+  it('Lobby: Toggles the How to Play modal', () => {
+    render(<Lobby onPlay={vi.fn()} onLogout={vi.fn()} username="Tester" />);
+    
+    expect(screen.queryByText(/HOW TO PLAY: GAME Y/i)).not.toBeInTheDocument();
+
+    const helpBtn = screen.getByTitle('How to Play'); 
+    fireEvent.click(helpBtn);
+
+    expect(screen.getByText(/HOW TO PLAY: GAME Y/i)).toBeInTheDocument();
+
+    const closeBtn = screen.getByText(/Got it!/i);
+    fireEvent.click(closeBtn);
+
+    expect(screen.queryByText(/HOW TO PLAY: GAME Y/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Added a responsive 'How to Play' modal to the Lobby explaining Game Y rules, complete with matching styling and animations.
Closes:https://github.com/Arquisoft/yovi_en1a/issues/96
<img width="1915" height="903" alt="image" src="https://github.com/user-attachments/assets/0c634c9b-5476-4bbc-86f7-c43b8e3e241f" />
